### PR TITLE
fix: fix local run command in template readme files

### DIFF
--- a/javascript-starter/README.md
+++ b/javascript-starter/README.md
@@ -1,5 +1,5 @@
-# Javascript Starter
+# JavaScript Starter
 
 ## Testing your app locally
 
-`nitric run "./functions/*.ts"`
+`nitric run`

--- a/typescript-starter/README.md
+++ b/typescript-starter/README.md
@@ -2,4 +2,4 @@
 
 ## Testing your app locally
 
-`nitric run "./functions/*.ts"`
+`nitric run`


### PR DESCRIPTION
The current readme includes the old version of the run command