### PR TITLE
fix: add template nitric.yaml files

### DIFF
--- a/javascript-starter/nitric.yaml
+++ b/javascript-starter/nitric.yaml
@@ -1,0 +1,3 @@
+name: javascript-starter
+handlers:
+- functions/*.js

--- a/typescript-starter/nitric.yaml
+++ b/typescript-starter/nitric.yaml
@@ -1,0 +1,3 @@
+name: typescript-starter
+handlers:
+- functions/*.ts


### PR DESCRIPTION
depends on: https://github.com/nitrictech/cli/pull/250

> ! don't merge until that other PR is merged

Add nitric.yaml files to all templates so they work without needing the CLI to create the file or set up the function glob pattern.

Related to: https://github.com/nitrictech/cli/issues/197