### PR TITLE
fix: ensure vscode debugger works

### DIFF
--- a/javascript-starter/package.json
+++ b/javascript-starter/package.json
@@ -8,8 +8,8 @@
   "dependencies": {
     "@nitric/sdk": "0.16.0"
   },
-  "resolutions": {
-    "**/node-pty": "1.1.0-beta5"
+  "engines": {
+    "node": ">=20.0.0"
   },
   "devDependencies": {
     "dotenv": "^16.0.2",

--- a/typescript-starter/package.json
+++ b/typescript-starter/package.json
@@ -4,8 +4,8 @@
   "description": "nitric typescript starter template",
   "main": "index.js",
   "private": true,
-  "resolutions": {
-    "**/node-pty": "1.1.0-beta5"
+  "engines": {
+    "node": ">=20.0.0"
   },
   "dependencies": {
     "@nitric/sdk": "0.16.0"


### PR DESCRIPTION
removes node-pty resolution and adds node v20+ engine compat. This ensures the vscode debugger will work.
